### PR TITLE
Updated badges + removed develop version of Go from build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.6
-  - tip
 
 before_install:
   - go get github.com/Masterminds/glide

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ralph-cli
 
-[![Build Status](https://travis-ci.org/allegro/ralph-cli.svg?branch=travis-wip)](https://travis-ci.org/allegro/ralph-cli)
-[![Coverage Status](https://coveralls.io/repos/github/allegro/ralph-cli/badge.svg?branch=travis-wip)](https://coveralls.io/github/allegro/ralph-cli?branch=travis-wip)
+[![Build Status](https://travis-ci.org/allegro/ralph-cli.svg?branch=develop)](https://travis-ci.org/allegro/ralph-cli)
+[![Coverage Status](https://coveralls.io/repos/github/allegro/ralph-cli/badge.svg?branch=develop)](https://coveralls.io/github/allegro/ralph-cli?branch=develop)
 
 A command-line interface for Ralph.
 


### PR DESCRIPTION
I'm removing develop version of Go from build matrix because yesterday I've got a failed build caused by some change in Go language itself, which in turn broke golint command, and therefore, this fail had nothing to do with our codebase (or even with golint).