### PR TITLE
Add ability to discover model name of DC Asset.

### DIFF
--- a/diff_test.go
+++ b/diff_test.go
@@ -225,8 +225,8 @@ func TestNewDiffComponent(t *testing.T) {
 	}
 	dcAsset := DataCenterAsset{
 		ID:              1,
-		FirmwareVersion: "1.1.1",
-		BIOSVersion:     "2.2.2",
+		FirmwareVersion: PtrTo("1.1.1"),
+		BIOSVersion:     PtrTo("2.2.2"),
 	}
 	var cases = map[string]struct {
 		component Component

--- a/helpers.go
+++ b/helpers.go
@@ -164,3 +164,9 @@ func (f FakeComponent) String() string {
 func (f FakeComponent) IsEqualTo(c Component) bool {
 	return false
 }
+
+// PtrTo returns a pointer to a string s, which may be useful for constructing
+// struct literals with *string fields.
+func PtrTo(s string) *string {
+	return &s
+}

--- a/main.go
+++ b/main.go
@@ -42,15 +42,16 @@ func main() {
 	app.Command("scan", "Perform scan of a given host/network", func(cmd *cli.Cmd) {
 		addr := cmd.StringArg("IP_ADDR", "", "IP address of a host to scan")
 		script := cmd.StringOpt("script", "", "Script to be executed")
+		withModel := cmd.BoolOpt("with-model", false, "Append detected model name to \"Remarks\" field in Ralph")
 		dryRun := cmd.BoolOpt("dry-run", false, "Don't write anything")
 
-		cmd.Spec = "IP_ADDR --script=<script_name> [--dry-run]"
+		cmd.Spec = "IP_ADDR --script=<script_name> [--with-model] [--dry-run]"
 
 		cmd.Action = func() {
 			if *script == "" {
 				log.Fatalln("No script supplied to '--script' switch. Aborting.")
 			}
-			PerformScan(*addr, *script, *dryRun, cfg, cfgDir)
+			PerformScan(*addr, *script, *withModel, *dryRun, cfg, cfgDir)
 		}
 	})
 

--- a/scan.go
+++ b/scan.go
@@ -120,16 +120,15 @@ func prepareEnv(oldEnv []string, addrToScan Addr, cfg *Config) (newEnv []string)
 // ScanResult holds parsed output of a scan script.
 type ScanResult struct {
 	// TODO(xor-xor): Consider adding here a field holding an ADDR being scanned.
-	// TODO(xor-xor): Consider using Model type instead of string here.
 	Ethernets         []Ethernet         `json:"ethernets"`
 	Memory            []Memory           `json:"memory"`
 	FibreChannelCards []FibreChannelCard `json:"fibre_channel_cards"`
 	Disks             []Disk             `json:"disks"`
-	ModelName         string             `json:"model_name"`
 	Processors        []Processor        `json:"processors"`
 	SN                string             `json:"serial_number"`
 	FirmwareVersion   string             `json:"firmware_version"`
 	BIOSVersion       string             `json:"bios_version"`
+	ModelName         string             `json:"model_name"`
 }
 
 func (sr ScanResult) String() string {


### PR DESCRIPTION
* discovered model name is appended to "Remarks" field in Ralph
* this functionality is triggered via `--with-model` switch

This PR should be merged **after** #26 (only b60f3da should be taken into account during code review).

@mkurek and @ar4s - let me know what you think about the name of that switch - it will be used like this: `ralph-cli scan 10.20.30.40 --scripts=idrac.py --with-model`.