### PR TITLE
Add `--components` and `--with-bios-and-firmware` switches to scan command.

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -11,7 +11,7 @@ import (
 
 // PerformScan runs a scan of a given host using a script with scriptName.
 // At this moment, we assume that only MAC addresses will be created/updated/deleted in Ralph.
-func PerformScan(addrStr, scriptName string, withModel, dryRun bool, cfg *Config, cfgDir string) {
+func PerformScan(addrStr, scriptName string, components map[string]bool, withBIOSAndFirmware, withModel, dryRun bool, cfg *Config, cfgDir string) {
 	if dryRun {
 		// TODO(xor-xor): Wire up logger here.
 		fmt.Println("INFO: Running in dry-run mode, no changes will be saved in Ralph.")
@@ -47,29 +47,42 @@ func PerformScan(addrStr, scriptName string, withModel, dryRun bool, cfg *Config
 	}
 
 	var changesDetected bool
-	if changed := getEthernets(addr, result, baseObj, client, dryRun); changed {
-		changesDetected = true
+	if components["eth"] || components["all"] {
+		if changed := getEthernets(addr, result, baseObj, client, dryRun); changed {
+			changesDetected = true
+		}
 	}
-	if changed := getMemory(result, baseObj, client, dryRun); changed {
-		changesDetected = true
+	if components["mem"] || components["all"] {
+		if changed := getMemory(result, baseObj, client, dryRun); changed {
+			changesDetected = true
+		}
 	}
-	if changed := getFibreChannelCards(result, baseObj, client, dryRun); changed {
-		changesDetected = true
+	if components["fcc"] || components["all"] {
+		if changed := getFibreChannelCards(result, baseObj, client, dryRun); changed {
+			changesDetected = true
+		}
 	}
-	if changed := getProcessors(result, baseObj, client, dryRun); changed {
-		changesDetected = true
+	if components["cpu"] || components["all"] {
+		if changed := getProcessors(result, baseObj, client, dryRun); changed {
+			changesDetected = true
+		}
 	}
-	if changed := getDisks(result, baseObj, client, dryRun); changed {
-		changesDetected = true
+	if components["disk"] || components["all"] {
+		if changed := getDisks(result, baseObj, client, dryRun); changed {
+			changesDetected = true
+		}
 	}
-	if changed := getBIOSAndFirmwareVersions(result, baseObj, client, dryRun); changed {
-		changesDetected = true
+	if withBIOSAndFirmware {
+		if changed := getBIOSAndFirmwareVersions(result, baseObj, client, dryRun); changed {
+			changesDetected = true
+		}
 	}
 	if withModel {
 		if changed := getModelName(result, baseObj, client, dryRun); changed {
 			changesDetected = true
 		}
 	}
+
 	if !changesDetected {
 		fmt.Println("No changes detected.")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseComponents(t *testing.T) {
+	var cases = map[string]struct {
+		components string
+		errMsg     string
+		want       *map[string]bool
+	}{
+		"#0 All valid components": {
+			"all,eth,mem,fcc,cpu,disk",
+			"",
+			&map[string]bool{
+				"all":  true,
+				"eth":  true,
+				"mem":  true,
+				"fcc":  true,
+				"cpu":  true,
+				"disk": true,
+			},
+		},
+		"#1 Unknown component": {
+			"eth,mem,printer",
+			"unknown component: printer",
+			nil,
+		},
+	}
+
+	for tn, tc := range cases {
+		got, err := parseComponents(tc.components)
+		switch {
+		case tc.errMsg != "":
+			if err == nil || !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("%s\ndidn't get expected string: %q in err msg: %q", tn, tc.errMsg, err)
+			}
+		default:
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("%s\n got: %v\nwant: %v", tn, got, tc.want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Example usage: `ralph-cli scan 10.20.30.40 --script=idrac.py --components=eth,mem --with-bios-and-firmware`.

This PR should be merged **after** #27 (only 24bf456 should be taken into account during code review).

@mkurek and @ar4s - let me know what do you guys think re: `--with-bios-and-firmware` - is such name OK? Or maybe it would be better to split it into two separate switches..? Or maybe not..? :wink: